### PR TITLE
hotfix/chroot improvement

### DIFF
--- a/zkclient.go
+++ b/zkclient.go
@@ -488,7 +488,6 @@ func (c *Client) ChildrenValues(p string) (children []string, values [][]byte, e
 		})
 	} else {
 		for retry := 0; retry < 3; retry++ {
-		RETRY:
 			children, c.stat, err = c.zkConn.Children(c.realPath(p))
 			if err != nil {
 				return
@@ -503,7 +502,7 @@ func (c *Client) ChildrenValues(p string) (children []string, values [][]byte, e
 					if err == zk.ErrNoNode {
 						// between Children() and Get() the znode might change: just get the latest znode
 						time.Sleep(blindBackoff)
-						goto RETRY
+						break // break inner loop, retry again
 					}
 
 					// unexpeced err

--- a/zkclient.go
+++ b/zkclient.go
@@ -461,7 +461,7 @@ func (c *Client) ChildrenValues(p string) (children []string, values [][]byte, e
 			values = make([][]byte, 0, len(children))
 			var data []byte
 			for _, child := range children {
-				if data, err = c.Get(c.realPath(gopath.Join(p, child))); err != nil {
+				if data, err = c.Get(gopath.Join(p, child)); err != nil {
 					return retry.RetryContinue, c.wrapZkError(p, err)
 				}
 
@@ -483,7 +483,7 @@ func (c *Client) ChildrenValues(p string) (children []string, values [][]byte, e
 			values = make([][]byte, 0, len(children))
 			var data []byte
 			for _, child := range children {
-				if data, err = c.Get(c.realPath(gopath.Join(p, child))); err != nil {
+				if data, err = c.Get(gopath.Join(p, child)); err != nil {
 					if err == zk.ErrNoNode {
 						// between Children() and Get() the znode might change: just get the latest znode
 						time.Sleep(blindBackoff)

--- a/zkclient_test.go
+++ b/zkclient_test.go
@@ -152,7 +152,6 @@ func TestChrootChildrenValues(t *testing.T) {
 	root := "/TestChildrenValues" + now.Format("20060102150405")
 	defer func() {
 		c.DeleteTree(root)
-		fmt.Println("delete root=", root)
 		c.Disconnect()
 	}()
 

--- a/zkclient_test.go
+++ b/zkclient_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 var (
-	testZkSvr = "localhost:2181"
+	testZkSvr  = "localhost:2181"
+	testZkSvr2 = "localhost:2181/chroot"
 )
 
 func init() {
@@ -125,6 +126,33 @@ func TestChildrenValues(t *testing.T) {
 	root := "/TestChildrenValues" + now.Format("20060102150405")
 	defer func() {
 		c.DeleteTree(root)
+		c.Disconnect()
+	}()
+
+	data := []byte("hello world")
+	assert.Equal(t, nil, c.CreatePersistent(root, data))
+	assert.Equal(t, nil, c.CreatePersistent(path.Join(root, "a"), data))
+	assert.Equal(t, nil, c.CreatePersistent(path.Join(root, "b"), data))
+
+	chilren, values, err := c.ChildrenValues(root)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, data, values[1])
+	assert.Equal(t, 2, len(values))
+	t.Logf("%+v %+v", chilren, values)
+}
+
+func TestChrootChildrenValues(t *testing.T) {
+	c := New(testZkSvr2)
+	c.SetSessionTimeout(time.Second * 41)
+	c.withRetry = false
+	err := c.Connect()
+	assert.Equal(t, nil, err)
+
+	now := time.Now()
+	root := "/TestChildrenValues" + now.Format("20060102150405")
+	defer func() {
+		c.DeleteTree(root)
+		fmt.Println("delete root=", root)
 		c.Disconnect()
 	}()
 


### PR DESCRIPTION
improve zk chroot for ChildrenValues function

1. remove chroot pending before calling Get()
2. fix infinite retry bug
3. add test case TestChrootChildrenValues